### PR TITLE
set LangVersion to 7.3 to allow VS2017 to compile the solution

### DIFF
--- a/Engine/JsonGo/JsonGo.csproj
+++ b/Engine/JsonGo/JsonGo.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
When I tried to compile the solution with VS2017 I got an error that some C# language features are not available.

Setting the LangVersion to 7.3 allowed VS2017 to compile the solution.